### PR TITLE
adding list support to the KeyValueMapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,6 +230,10 @@ mapper can combine multiple records into a single result if there is an
 * ``SingleRowAndColumnMapper`` - returns a single scalar value even if multiple records and columns are returned
   from the database.
 * ``CountMapper`` - alias for ``SingleRowAndColumnMapper`` to make it clear that it may be used for ``count`` queries.
+* ``KeyValueMapper`` - returns a dictionary mapping 1 column to the keys and 1 column to the values.
+  By default the key is mapped to the first column and value is mapped to the second column. You can override the key_column
+  and value_columns by specifying the name of the colums you want for each. You can also pass in a has_multiple_values
+  which defaults to False. Doing so will allow you to get a dictionary of lists based on the keys and values you specify
 * Custom mappers may be made by extending the ``BaseMapper`` class and implementing the ``map_records`` method.
 
 basic query with conditions hardcoded into query and default mapper
@@ -299,8 +303,33 @@ basic count query that only returns the scalar value returned for the count
         return get_count_for_name('joe')
 
     @sqlquery(mapper=CountMapper)
-    def get_count_for_name(name)
+    def get_count_for_name(name):
         return QueryData("SELECT COUNT(*) FROM table WHERE name=:name", query_params={'name': name})
+
+
+basic query returning dictionary
+
+.. code-block:: python
+
+    @sqlquery(mapper=KeyValueMapper())
+    def get_status_by_name():
+        return QueryData("SELECT name, status FROM table")
+
+query returning a dictionary where we are specifying the keys. Note that the columns are returning in a different order
+
+.. code-block:: python
+
+    @sqlquery(mapper=KeyValueMapper(key_column='name', value_column='status'))
+    def get_status_by_name():
+        return QueryData("SELECT status, name FROM table")
+
+query returning a dictionary where there are multiple results under each key. Note that here we are essentially grouping under status
+
+.. code-block:: python
+
+    @sqlquery(mapper=KeyValueMapper(key_column='status', value_column='name', has_multiple_values=True))
+    def get_status_by_name():
+        return QueryData("SELECT status, name FROM table")
 
 
 @sqlupdate

--- a/README.rst
+++ b/README.rst
@@ -232,8 +232,8 @@ mapper can combine multiple records into a single result if there is an
 * ``CountMapper`` - alias for ``SingleRowAndColumnMapper`` to make it clear that it may be used for ``count`` queries.
 * ``KeyValueMapper`` - returns a dictionary mapping 1 column to the keys and 1 column to the values.
   By default the key is mapped to the first column and value is mapped to the second column. You can override the key_column
-  and value_columns by specifying the name of the colums you want for each. You can also pass in a has_multiple_values
-  which defaults to False. Doing so will allow you to get a dictionary of lists based on the keys and values you specify
+  and value_columns by specifying the name of the columns you want for each. You can also pass in a has_multiple_values
+  which defaults to False. Doing so will allow you to get a dictionary of lists based on the keys and values you specify.
 * Custom mappers may be made by extending the ``BaseMapper`` class and implementing the ``map_records`` method.
 
 basic query with conditions hardcoded into query and default mapper

--- a/dysql/test/test_mappers.py
+++ b/dysql/test/test_mappers.py
@@ -12,8 +12,9 @@ from dysql import (
     SingleRowMapper,
     SingleColumnMapper,
     SingleRowAndColumnMapper,
-    CountMapper
+    CountMapper, KeyValueMapper
 )
+from dysql.mappers import MapperError
 
 
 class TestMappers:
@@ -34,9 +35,9 @@ class TestMappers:
             {'id': 2, 'a': 1, 'b': 2},
             {'id': 1, 'c': 3},
         ])) == [
-            {'id': 1, 'a': 1, 'b': 2, 'c': 3},
-            {'id': 2, 'a': 1, 'b': 2},
-        ]
+                   {'id': 1, 'a': 1, 'b': 2, 'c': 3},
+                   {'id': 2, 'a': 1, 'b': 2},
+               ]
 
     @staticmethod
     def test_record_combining_no_record_mapper():
@@ -48,10 +49,10 @@ class TestMappers:
             {'id': 2, 'a': 1, 'b': 2},
             {'id': 1, 'c': 3},
         ]) == [
-            {'id': 1, 'a': 1, 'b': 2},
-            {'id': 2, 'a': 1, 'b': 2},
-            {'id': 1, 'c': 3},
-        ]
+                   {'id': 1, 'a': 1, 'b': 2},
+                   {'id': 2, 'a': 1, 'b': 2},
+                   {'id': 1, 'c': 3},
+               ]
 
     @staticmethod
     def test_single_row():
@@ -87,13 +88,12 @@ class TestMappers:
         ]) == ['myid1', 'myid2', 'myid3']
 
     @staticmethod
-    @pytest.mark.parametrize('_cls', [
-        SingleRowAndColumnMapper,
+    @pytest.mark.parametrize('mapper', [
+        SingleRowAndColumnMapper(),
         # Alias for the other one
-        CountMapper,
+        CountMapper(),
     ])
-    def test_single_column_and_row(_cls):
-        mapper = _cls()
+    def test_single_column_and_row(mapper):
         assert mapper.map_records([]) is None
         assert mapper.map_records([{'a': 1, 'b': 2}]) == 1
         assert mapper.map_records([
@@ -101,3 +101,52 @@ class TestMappers:
             {'id': 2, 'a': 1, 'b': 2},
             {'id': 1, 'c': 3},
         ]) == 'myid'
+
+    @staticmethod
+    @pytest.mark.parametrize('mapper, expected', [
+        (KeyValueMapper(), {'a': 4, 'b': 7}),
+        (KeyValueMapper(key_column='column_named_something'), {'a': 4, 'b': 7}),
+        (KeyValueMapper(value_column='column_with_some_value'), {'a': 4, 'b': 7}),
+        (KeyValueMapper(has_multiple_values_per_key=True), {'a': [1, 2, 3, 4], 'b': [3, 4, 5, 6, 7]}),
+        (KeyValueMapper(key_column='column_named_something', has_multiple_values_per_key=True),
+         {'a': [1, 2, 3, 4], 'b': [3, 4, 5, 6, 7]}),
+        (KeyValueMapper(key_column='column_with_some_value', value_column='column_named_something',
+                        has_multiple_values_per_key=True),
+         {1: ['a'], 2: ['a'], 3: ['a', 'b'], 4: ['a', 'b'], 5: ['b'], 6: ['b'], 7: ['b']}),
+        (KeyValueMapper(key_column='column_with_some_value', value_column='column_named_something'),
+         {1: 'a', 2: 'a', 3: 'b', 4: 'b', 5: 'b', 6: 'b', 7: 'b'}),
+    ])
+    def test_key_mapper_key_has_multiple(mapper, expected):
+        result = mapper.map_records([
+            TestRow(('column_named_something', 'column_with_some_value'), ['a', 1]),
+            TestRow(('column_named_something', 'column_with_some_value'), ['a', 2]),
+            TestRow(('column_named_something', 'column_with_some_value'), ['a', 3]),
+            TestRow(('column_named_something', 'column_with_some_value'), ['a', 4]),
+            TestRow(('column_named_something', 'column_with_some_value'), ['b', 3]),
+            TestRow(('column_named_something', 'column_with_some_value'), ['b', 4]),
+            TestRow(('column_named_something', 'column_with_some_value'), ['b', 5]),
+            TestRow(('column_named_something', 'column_with_some_value'), ['b', 6]),
+            TestRow(('column_named_something', 'column_with_some_value'), ['b', 7]),
+        ])
+        assert len(result) == len(expected)
+        assert result == expected
+
+    @staticmethod
+    def test_key_mapper_key_value_same():
+        with pytest.raises(MapperError, match='key and value columns cannot be the same'):
+            KeyValueMapper(key_column='same', value_column='same')
+
+
+class TestRow:  # pylint: disable=too-few-public-methods
+    """
+    Helper class does the most basic functionality we see when accessing records passed in
+    """
+
+    def __init__(self, fields, values):
+        self.fields = fields
+        self.values = values
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return self.values[key]
+        return self.values[self.fields.index(key)]

--- a/dysql/test/test_mappers.py
+++ b/dysql/test/test_mappers.py
@@ -28,7 +28,7 @@ class TestMappers:
 
     def test_record_combining(self):
         mapper = RecordCombiningMapper()
-        assert mapper.map_records([]) == []
+        assert len(mapper.map_records([])) == 0
         assert self._unwrap_results(mapper.map_records([{'a': 1, 'b': 2}])) == [{'a': 1, 'b': 2}]
         assert self._unwrap_results(mapper.map_records([
             {'id': 1, 'a': 1, 'b': 2},
@@ -42,7 +42,7 @@ class TestMappers:
     @staticmethod
     def test_record_combining_no_record_mapper():
         mapper = RecordCombiningMapper(record_mapper=None)
-        assert mapper.map_records([]) == []
+        assert len(mapper.map_records([])) == 0
         assert mapper.map_records([{'a': 1, 'b': 2}]) == [{'a': 1, 'b': 2}]
         assert mapper.map_records([
             {'id': 1, 'a': 1, 'b': 2},
@@ -79,7 +79,7 @@ class TestMappers:
     @staticmethod
     def test_single_column():
         mapper = SingleColumnMapper()
-        assert mapper.map_records([]) == []
+        assert len(mapper.map_records([])) == 0
         assert mapper.map_records([{'a': 1, 'b': 2}]) == [1]
         assert mapper.map_records([
             {'id': 'myid1', 'a': 1, 'b': 2},

--- a/dysql/test/test_pydantic_mappers.py
+++ b/dysql/test/test_pydantic_mappers.py
@@ -52,7 +52,7 @@ def test_field_conversion():
 
 def test_complex_object_record_combining():
     mapper = RecordCombiningMapper(record_mapper=CombiningDbModel)
-    assert mapper.map_records([]) == []
+    assert len(mapper.map_records([])) == 0
     assert _unwrap_results(mapper.map_records([
         {'id': 1, 'list1': 'val1', 'set1': 'val2', 'key1': 'k1', 'val1': 'v1', 'key2': 'k3', 'val2': 3},
         {'id': 2, 'list1': 'val1'},


### PR DESCRIPTION

## Motivation and Context
	its nice to be able to aggregate sql queries into lists
	keyed by a specific value, this allows us to pass in
	some parameters to the KeyValueMapper to override the
	default behavior.

	the default behavior should still be backwards compatible with
	the existing usages

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?

        added parametrized testing around the KeyValueMapper to ensure
        both new and existing usages work as expected


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.