### PR TITLE
select exists is not select 1 where exists

### DIFF
--- a/dysql/connections.py
+++ b/dysql/connections.py
@@ -160,8 +160,10 @@ def sqlexists(isolation_level='READ_COMMITTED'):
                 query, params = get_query_data(data)
 
                 query = query.lstrip()
-                if not query.startswith('SELECT EXISTS'):
-                    query = f'SELECT EXISTS ( {query} )'
+                if query.startswith('SELECT EXISTS'):
+                    query = query.replace('SELECT EXISTS', 'SELECT 1 WHERE EXISTS')
+                if not query.startswith('SELECT 1 WHERE EXISTS'):
+                    query = f'SELECT 1 WHERE EXISTS ( {query} )'
                 result = conn_manager.execute_query(query, params).scalar()
                 return result == 1
 


### PR DESCRIPTION
	this helps avoid an issue when using the @exists
	decorator when the database client is using `utf8`.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.