### PR TITLE
Add database init hook for enabling tracing applications

### DIFF
--- a/dysql/__init__.py
+++ b/dysql/__init__.py
@@ -23,6 +23,11 @@ from .connections import (
     sqlquery,
     sqlupdate,
 )
-from .databases import is_set_current_database_supported, reset_current_database, set_current_database, \
-    set_default_connection_parameters
+from .databases import (
+    is_set_current_database_supported,
+    reset_current_database,
+    set_current_database,
+    set_database_init_hook,
+    set_default_connection_parameters,
+)
 from .exceptions import DBNotPreparedError

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import types
 from setuptools import setup, find_packages
 
 
-BASE_VERSION = '1.12'
+BASE_VERSION = '1.13'
 SOURCE_DIR = os.path.dirname(
     os.path.abspath(__file__)
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds a new feature for calling a method after each database engine is initialized.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

I want to add tracing into my applications, but need a hook into the engine creation process first.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.