### PR TITLE
Refactoring map_list_from_string

### DIFF
--- a/dysql/pydantic_mappers.py
+++ b/dysql/pydantic_mappers.py
@@ -92,16 +92,16 @@ class DbMapResultModel(BaseModel, DbMapResultBase):
         list_string = record[field]
         if list_string and isinstance(list_string, str):
             values_from_string = list_string.split(',')
+            model_field = self.__fields__[field]
+            # pre-validates the list we are expecting because we want to ensure all records are validated
+            values, errors_ = model_field.validate(values_from_string, current_dict, loc=model_field.alias)
+            if errors_:
+                raise ValidationError(errors_, DbMapResultModel)
 
-            if self._has_been_mapped():
-                # validates the list we are expecting and updates all fields to the expected type or throws error
-                model_field = self.__fields__[field]
-                values, errors_ = model_field.validate(values_from_string, current_dict, loc=model_field.alias)
-                if errors_:
-                    raise ValidationError(errors_, DbMapResultModel)
+            if self._has_been_mapped() and current_dict[field]:
                 current_dict[field].extend(values)
             else:
-                current_dict[field] = values_from_string
+                current_dict[field] = values
 
     def map_record(self, record: sqlalchemy.engine.Row) -> None:
         """

--- a/dysql/test/test_pydantic_mappers.py
+++ b/dysql/test/test_pydantic_mappers.py
@@ -154,6 +154,23 @@ def test_csv_list_field_multiple_records_duplicates():
            }
 
 
+def test_csv_list_field_none_in_first_record():
+    mapper = RecordCombiningMapper(record_mapper=ListWithStringsModel)
+    assert mapper.map_records([{
+        'id': 1,
+        'list1': 'a,b,c,d',
+        'list2': None
+    }, {
+        'id': 1,
+        'list1': 'e,f,g',
+        'list2': '1,2,3,4'
+    }])[0].raw() == {
+               'id': 1,
+               'list1': ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+               'list2': [1, 2, 3, 4]
+           }
+
+
 def test_csv_list_field_without_mapping_ignored():
     mapper = SingleRowMapper(record_mapper=ListWithStringsModel)
     assert mapper.map_records([{


### PR DESCRIPTION
	handling the case where a string value may not have been
	found in the first record. when this happens the
	_has_been_mapped would still be true after the first record
	and the array would never get set so extending would be
	trying to extend from none

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.