### PR TITLE
adding support for multi-column ids in RecordCombiningMapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -258,7 +258,9 @@ mapper can combine multiple records into a single result if there is an
 ``id`` field present in each record. Mappers available:
 
 * ``RecordCombiningMapper`` (default) - returns a list of results, with multiple records with the same ``id`` value
-  being combined into a single result. An optional ``record_mapper`` value may be passed to the constructor to change
+  being combined into a single result. By default the column ``id`` is used but an array of column names can be used
+  to create a unique key lookup for combining records. The id value can be set as one or more columns in the mapper.
+  An optional ``record_mapper`` value may be passed to the constructor to change
   how records are mapped to result. By default the ``record_mapper`` used is ``DbMapResult``.
 * ``SingleRowMapper`` - returns an object for the first record from the database (even if multiple records are
   returned). An optional ``record_mapper`` value may be passed to the constructor to change how this first record is

--- a/dysql/mappers.py
+++ b/dysql/mappers.py
@@ -152,6 +152,8 @@ class RecordCombiningMapper(BaseMapper):
         values = []
         for column in self.id_columns:
             if column not in record:
+                LOGGER.warning(f'There was an invalid column specified in {self.id_columns}. '
+                               f'Because of this id_columns will not be used for a unique key.')
                 # returning none because we don't want to make assumptions about how to handle a complex key
                 return None
             values.append(record[column])

--- a/dysql/test/test_mappers.py
+++ b/dysql/test/test_mappers.py
@@ -5,10 +5,7 @@ All Rights Reserved.
 NOTICE: Adobe permits you to use, modify, and distribute this file in accordance
 with the terms of the Adobe license agreement accompanying it.
 """
-from typing import List
-
 import pytest
-from pydantic.main import BaseModel
 
 from dysql import (
     RecordCombiningMapper,

--- a/dysql/test/test_mappers.py
+++ b/dysql/test/test_mappers.py
@@ -5,7 +5,10 @@ All Rights Reserved.
 NOTICE: Adobe permits you to use, modify, and distribute this file in accordance
 with the terms of the Adobe license agreement accompanying it.
 """
+from typing import List
+
 import pytest
+from pydantic.main import BaseModel
 
 from dysql import (
     RecordCombiningMapper,

--- a/dysql/test/test_pydantic_mappers.py
+++ b/dysql/test/test_pydantic_mappers.py
@@ -18,7 +18,6 @@ from dysql import (
 from dysql.pydantic_mappers import DbMapResultModel
 
 
-
 class ConversionDbModel(DbMapResultModel):
     id: int
     field_str: str


### PR DESCRIPTION
	there are times when more than one column defines
	the uniqueness of a record we want to combine.

	this lets you specify what columns are part of the id
	and uses the values from those columns as a unique lookup.
	if those columns are missing or don't have a value we don't
	guess, we just fall back to each record being its on instance
	and don't try to combine anything.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.