### PR TITLE
Pin sqlalchemy version to 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ setup(
     packages=find_packages(exclude=('*test*',)),
     zip_safe=False,
     install_requires=(
-        'sqlalchemy>=1.4',
+        # SQLAlchemy 2+ is not yet submitted
+        'sqlalchemy<2',
     ),
     extras_require={
         'pydantic': ['pydantic>=1.8.2,<2'],


### PR DESCRIPTION
It doesn't work with sqlalchemy 2+. We are planning on this work at some point, but pinning the version for now.