### PR TITLE
adding support for including a get_last_insert_id

### DIFF
--- a/dysql/connections.py
+++ b/dysql/connections.py
@@ -124,7 +124,7 @@ def sqlquery(
                 actual_mapper = actual_mapper()
 
             with _ConnectionManager(
-                    func, isolation_level, False, *args, **kwargs
+                func, isolation_level, False, *args, **kwargs
             ) as conn_manager:
                 data = func(*args, **kwargs)
                 query, params = get_query_data(data)
@@ -161,7 +161,7 @@ def sqlexists(isolation_level="READ_COMMITTED"):
         def handle_query(*args, **kwargs):
             functools.wraps(func, handle_query)
             with _ConnectionManager(
-                    func, isolation_level, False, *args, **kwargs
+                func, isolation_level, False, *args, **kwargs
             ) as conn_manager:
                 data = func(*args, **kwargs)
                 query, params = get_query_data(data)
@@ -183,7 +183,7 @@ def sqlupdate(
     isolation_level="READ_COMMITTED",
     disable_foreign_key_checks=False,
     on_success=None,
-    use_get_last_insert_id=False
+    use_get_last_insert_id=False,
 ):
     """
     :param isolation_level should specify whether we can read data from transactions that are not
@@ -242,13 +242,15 @@ def sqlupdate(
         def handle_query(*args, **kwargs):
             functools.wraps(func)
             with _ConnectionManager(
-                    func, isolation_level, True, *args, **kwargs
+                func, isolation_level, True, *args, **kwargs
             ) as conn_manager:
                 if disable_foreign_key_checks:
                     conn_manager.execute_query("SET FOREIGN_KEY_CHECKS=0")
-                last_insert_method = 'get_last_insert_id'
+                last_insert_method = "get_last_insert_id"
                 if use_get_last_insert_id:
-                    kwargs[last_insert_method] = lambda: conn_manager.execute_query("SELECT LAST_INSERT_ID()").scalar()
+                    kwargs[last_insert_method] = lambda: conn_manager.execute_query(
+                        "SELECT LAST_INSERT_ID()"
+                    ).scalar()
                 if inspect.isgeneratorfunction(func):
                     logger.debug("handling each query before committing transaction")
 

--- a/dysql/test/test_sql_insert_templates.py
+++ b/dysql/test/test_sql_insert_templates.py
@@ -154,7 +154,7 @@ def insert_into_single_value(names):
 
 
 def test_last_insert_id():
-    @sqlupdate(use_get_last_insert_id=True)
+    @sqlupdate()
     def insert(get_last_insert_id=None):
         yield QueryData("INSERT INTO get_last(name) VALUES ('Tom')")
         assert get_last_insert_id
@@ -169,9 +169,7 @@ def test_last_insert_id_removed_before_callback():
     def callback(**kwargs):
         assert "get_last_insert_id" not in kwargs
 
-    @sqlupdate(
-        use_get_last_insert_id=True,
-    )
+    @sqlupdate()
     def insert(get_last_insert_id=None):
         assert get_last_insert_id
         yield QueryData("INSERT INTO get_last(name) VALUES ('Tom')")

--- a/dysql/test/test_sql_insert_templates.py
+++ b/dysql/test/test_sql_insert_templates.py
@@ -22,15 +22,16 @@ _ = mock_create_engine_fixture
 
 @pytest.fixture(name="mock_engine", autouse=True)
 def mock_engine_fixture(mock_create_engine):
-
     initial_id = 0
-    def handle_execute(query = None, args = None):
+
+    def handle_execute(query=None, args=None):
         nonlocal initial_id
         if "INSERT INTO get_last(name)" in query.text:
             initial_id += 1
         if "SELECT LAST_INSERT_ID()" == query.text:
             return type("Result", (), {"scalar": lambda: initial_id})
         return []
+
     mock_engine = setup_mock_engine(mock_create_engine)
     execute_mock = mock_engine.connect().execution_options().execute
     execute_mock.side_effect = handle_execute
@@ -154,22 +155,27 @@ def insert_into_single_value(names):
 
 def test_last_insert_id():
     @sqlupdate(use_get_last_insert_id=True)
-    def insert(get_last_insert_id = None):
+    def insert(get_last_insert_id=None):
         yield QueryData("INSERT INTO get_last(name) VALUES ('Tom')")
         assert get_last_insert_id
         assert get_last_insert_id() == 1
         yield QueryData("INSERT INTO get_last(name) VALUES ('Jerry')")
         assert get_last_insert_id() == 2
+
     insert()
+
 
 def test_last_insert_id_removed_before_callback():
     def callback(**kwargs):
         assert "get_last_insert_id" not in kwargs
 
-    @sqlupdate(use_get_last_insert_id=True,)
-    def insert( get_last_insert_id = None):
+    @sqlupdate(
+        use_get_last_insert_id=True,
+    )
+    def insert(get_last_insert_id=None):
         assert get_last_insert_id
         yield QueryData("INSERT INTO get_last(name) VALUES ('Tom')")
         yield QueryData("INSERT INTO get_last(name) VALUES ('Jerry')")
         assert get_last_insert_id() == 2
+
     insert()


### PR DESCRIPTION
	this enables us to pass a get_last_insert_id to a
	method with a @sqlupdate annotation defined as a
	kwarg.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.